### PR TITLE
Fix incorrect escaping of URL parameters.

### DIFF
--- a/Common/Src/Utils/HttpUtils.cs
+++ b/Common/Src/Utils/HttpUtils.cs
@@ -48,15 +48,15 @@ namespace Oci.Common.Utils
                 }
                 else if (collectionFormat == CollectionFormatType.Pipes)
                 {
-                    return $"{queryKey}={string.Join(Uri.EscapeUriString("|"), queryValues)}";
+                    return $"{queryKey}={string.Join(Uri.EscapeDataString("|"), queryValues)}";
                 }
                 else if (collectionFormat == CollectionFormatType.Ssv)
                 {
-                    return $"{queryKey}={string.Join(Uri.EscapeUriString(" "), queryValues)}";
+                    return $"{queryKey}={string.Join(Uri.EscapeDataString(" "), queryValues)}";
                 }
                 else if (collectionFormat == CollectionFormatType.Tsv)
                 {
-                    return $"{queryKey}={string.Join(Uri.EscapeUriString("\t"), queryValues)}";
+                    return $"{queryKey}={string.Join(Uri.EscapeDataString("\t"), queryValues)}";
                 }
                 else if (collectionFormat == CollectionFormatType.Multi)
                 {
@@ -97,7 +97,7 @@ namespace Oci.Common.Utils
             {
                 return GetEnumString(queryParam);
             }
-            return Uri.EscapeUriString(queryParam.ToString());
+            return Uri.EscapeDataString(queryParam.ToString());
         }
 
         /// <summary>Gets the actual Enum string representation that will be passed in HTTP request and recognized by service backend.</summary>
@@ -109,9 +109,9 @@ namespace Oci.Common.Utils
             var attr = memInfo[0].GetCustomAttributes(false).OfType<EnumMemberAttribute>().FirstOrDefault();
             if (attr != null)
             {
-                return Uri.EscapeUriString(attr.Value);
+                return Uri.EscapeDataString(attr.Value);
             }
-            return Uri.EscapeUriString(enumObject.ToString());
+            return Uri.EscapeDataString(enumObject.ToString());
         }
 
         /// <summary>Builds the string containing the query in request URL.</summary>

--- a/Commontests/Utils/HttpUtilsTests.cs
+++ b/Commontests/Utils/HttpUtilsTests.cs
@@ -69,10 +69,12 @@ namespace Oci.Common.Utils
         [DisplayTestMethodNameAttribute]
         public void EncodeQueryParam_String()
         {
-            var str = "string with space";
+            var str = "string with space and #";
             var escapedString = HttpUtils.EncodeQueryParam("key", str, Oci.Common.Http.CollectionFormatType.Csv);
             Assert.False(escapedString.Contains(" "), $"Escaped string {escapedString} should not contain \" \"");
+            Assert.False(escapedString.Contains("#"), $"Escaped string {escapedString} should not contain \"#\"");
             Assert.True(escapedString.Contains("%20"), $"Escaped string {escapedString} should contain \"%20\"");
+            Assert.True(escapedString.Contains("%23"), $"Escaped string {escapedString} should contain \"%23\"");
         }
 
         [Theory]
@@ -88,11 +90,11 @@ namespace Oci.Common.Utils
 
         public static IEnumerable<object[]> CollectionFormatTestData()
         {
-            yield return new object[] { new List<string> { "val1", "val2" }, Oci.Common.Http.CollectionFormatType.Csv, "key=val1,val2" };
-            yield return new object[] { new List<string> { "val1", "val2" }, Oci.Common.Http.CollectionFormatType.Multi, "key=val1&key=val2" };
-            yield return new object[] { new List<string> { "val1", "val2" }, Oci.Common.Http.CollectionFormatType.Pipes, "key=val1%7Cval2" };
-            yield return new object[] { new List<string> { "val1", "val2" }, Oci.Common.Http.CollectionFormatType.Ssv, "key=val1%20val2" };
-            yield return new object[] { new List<string> { "val1", "val2" }, Oci.Common.Http.CollectionFormatType.Tsv, "key=val1%09val2" };
+            yield return new object[] { new List<string> { "val&1%", "val#2" }, Oci.Common.Http.CollectionFormatType.Csv, "key=val%261%25,val%232" };
+            yield return new object[] { new List<string> { "val&1", "val #2" }, Oci.Common.Http.CollectionFormatType.Multi, "key=val%261&key=val%20%232" };
+            yield return new object[] { new List<string> { "val&1", "val#2" }, Oci.Common.Http.CollectionFormatType.Pipes, "key=val%261%7Cval%232" };
+            yield return new object[] { new List<string> { "val&1", "val#2" }, Oci.Common.Http.CollectionFormatType.Ssv, "key=val%261%20val%232" };
+            yield return new object[] { new List<string> { "val&1", "val#2" }, Oci.Common.Http.CollectionFormatType.Tsv, "key=val%261%09val%232" };
         }
     }
 }


### PR DESCRIPTION
We are escaping data elements as part of the Query parameter escaping.  So use EscapeDataString, which is for that purpose.

See: https://stackoverflow.com/questions/4396598/whats-the-difference-between-escapeuristring-and-escapedatastring

For a discussion on the implications.